### PR TITLE
Replace non-alphanumeric with a space in count_it.py

### DIFF
--- a/gangagsoc/count_it.py
+++ b/gangagsoc/count_it.py
@@ -28,7 +28,7 @@ def preprocess_text(text):
 
     # replace brackets first, then the rest
     clean_text = re.sub(square_brackets, ' ', text.lower())    
-    clean_text = re.sub(non_alpha_numeric, '', clean_text)
+    clean_text = re.sub(non_alpha_numeric, ' ', clean_text)
 
     return clean_text
 


### PR DESCRIPTION
The previous logic (replace with empty string) was missing an edge case.