### PR TITLE
debug: added space in the assertion logic

### DIFF
--- a/test/test_CountIt.py
+++ b/test/test_CountIt.py
@@ -23,7 +23,7 @@ class TestCountIt(unittest.TestCase):
 
         text = "The Large Hadron Collider! [citation] {CERN} more TEXT."
         self.assertEqual(preprocess_text(text),\
-            "the large hadron collider   citation   cern  more text", "Text preprocessing incorrect.")
+            "the large hadron collider   citation   cern  more text ", "Text preprocessing incorrect.")
 
     def testCountWord(self):
         from gangagsoc.count_it import count_word


### PR DESCRIPTION
Test was failing because the last update to the unit test `testPreprocessText` was buggy.